### PR TITLE
Add laserscan support to quanergy client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,8 @@ set(QUANERGY_CLIENT_VERSION "4.1.2")
 #required to prevent macro definition of min and max in windows
 add_definitions(-DNOMINMAX)
 
-SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+set(CMAKE_CXX_STANDARD 14)
+SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
 
 option(NoViz "Do not build visualizer" OFF)
 

--- a/apps/dynamic_connection.cpp
+++ b/apps/dynamic_connection.cpp
@@ -156,7 +156,7 @@ int main(int argc, char** argv)
   ////////////////////////////////////////////
   // here we'll simply count the number of packets and output every 100
   unsigned int cloud_count = 0;
-  connections.push_back(pipeline.connect(
+  connections.push_back(pipeline.connect_cloud(
       [&cloud_count](const boost::shared_ptr<pcl::PointCloud<quanergy::PointXYZIR>>& /*pc*/)
       { ++cloud_count; if(cloud_count % 100 == 0) std::cout << "clouds received: " << cloud_count << std::endl; }
   ));

--- a/apps/visualizer.cpp
+++ b/apps/visualizer.cpp
@@ -169,7 +169,7 @@ int main(int argc, char** argv)
   /// connect application specific logic here to consume the point cloud
   ////////////////////////////////////////////
   // connect the pipeline to the visualizer
-  connections.push_back(pipeline->connect(
+  connections.push_back(pipeline->connect_cloud(
       [&visualizer](const boost::shared_ptr<pcl::PointCloud<quanergy::PointXYZIR>>& pc){ visualizer->slot(pc); }
   ));
 

--- a/include/quanergy/pipelines/sensor_pipeline.h
+++ b/include/quanergy/pipelines/sensor_pipeline.h
@@ -27,7 +27,7 @@
 // module to apply encoder correction
 #include <quanergy/modules/encoder_angle_calibration.h>
 
-// async module for multithreading
+// cloud_async module for multithreading
 #include <quanergy/pipelines/async.h>
 
 // for setting file
@@ -74,9 +74,12 @@ namespace quanergy
       quanergy::client::RingIntensityFilter ring_intensity_filter;
       // polar to cart converter; converts from the polar PCL cloud to a Cartesian one
       quanergy::client::PolarToCartConverter cartesian_converter;
-      // async module to put the processing of the output cloud on a separate thread
-      using AsyncType = quanergy::pipeline::AsyncModule<boost::shared_ptr<pcl::PointCloud<quanergy::PointXYZIR>>>;
-      AsyncType async;
+      // cloud_async module to put the processing of the output cloud on a separate thread
+      using CloudAsyncType = quanergy::pipeline::AsyncModule<boost::shared_ptr<pcl::PointCloud<quanergy::PointXYZIR>>>;
+      CloudAsyncType cloud_async;
+
+      using ScanAsyncType = quanergy::pipeline::AsyncModule<boost::shared_ptr<pcl::PointCloud<quanergy::PointHVDIR>>>;
+      ScanAsyncType scan_async;
 
 
       // vector to hold connections for better cleanup
@@ -103,10 +106,21 @@ namespace quanergy
        *         const boost::shared_ptr<pcl::PointCloud<quanergy::PointXYZIR>>&
        *  \returns connection object created
        */
-      boost::signals2::connection connect(
-          const typename AsyncType::Signal::slot_type& subscriber)
+      boost::signals2::connection connect_cloud(
+          const typename CloudAsyncType::Signal::slot_type& subscriber)
       {
-        return async.connect(subscriber);
+        return cloud_async.connect(subscriber);
+      }
+
+      /** \brief connect is just a convenience calling the ring intensity filter's connect method
+       *  \param subscriber is the slot to call; it is a function consuming
+       *         const boost::shared_ptr<pcl::PointCloud<quanergy::PointHVDIR>>&
+       *  \returns connection object created
+       */
+      boost::signals2::connection connect_scan(
+          const typename ScanAsyncType::Signal::slot_type& subscriber)
+      {
+        return scan_async.connect(subscriber);
       }
     };
   }

--- a/include/quanergy/pipelines/sensor_pipeline.h
+++ b/include/quanergy/pipelines/sensor_pipeline.h
@@ -27,7 +27,7 @@
 // module to apply encoder correction
 #include <quanergy/modules/encoder_angle_calibration.h>
 
-// cloud_async module for multithreading
+// async module for multithreading
 #include <quanergy/pipelines/async.h>
 
 // for setting file
@@ -74,7 +74,7 @@ namespace quanergy
       quanergy::client::RingIntensityFilter ring_intensity_filter;
       // polar to cart converter; converts from the polar PCL cloud to a Cartesian one
       quanergy::client::PolarToCartConverter cartesian_converter;
-      // cloud_async module to put the processing of the output cloud on a separate thread
+      // async modules to put the processing of the output cloud on a separate thread
       using CloudAsyncType = quanergy::pipeline::AsyncModule<boost::shared_ptr<pcl::PointCloud<quanergy::PointXYZIR>>>;
       CloudAsyncType cloud_async;
 

--- a/src/pipelines/sensor_pipeline.cpp
+++ b/src/pipelines/sensor_pipeline.cpp
@@ -192,12 +192,12 @@ namespace quanergy
 
       // connect to an async module so downstream work happens on a separate thread
       connections.push_back(cartesian_converter.connect(
-          [this](const quanergy::client::PolarToCartConverter::ResultType& pc){ async.slot(pc); }
+          [this](const quanergy::client::PolarToCartConverter::ResultType& pc){ cloud_async.slot(pc); }
       ));
 
       // also make the polar-frame data available to downstream worker threads
       connections.push_back(ring_intensity_filter.connect(
-          [this](const quanergy::client::RingIntensityFilter::ResultType& pc)){ async.slot(pc); }
+          [this](const quanergy::client::RingIntensityFilter::ResultType& pc){ scan_async.slot(pc); }
       ));
     }
 

--- a/src/pipelines/sensor_pipeline.cpp
+++ b/src/pipelines/sensor_pipeline.cpp
@@ -194,6 +194,11 @@ namespace quanergy
       connections.push_back(cartesian_converter.connect(
           [this](const quanergy::client::PolarToCartConverter::ResultType& pc){ async.slot(pc); }
       ));
+
+      // also make the polar-frame data available to downstream worker threads
+      connections.push_back(ring_intensity_filter.connect(
+          [this](const quanergy::client::RingIntensityFilter::ResultType& pc)){ async.slot(pc); }
+      ));
     }
 
     SensorPipeline::~SensorPipeline()

--- a/test/test_encoder_angle_calibration.cpp
+++ b/test/test_encoder_angle_calibration.cpp
@@ -9,6 +9,7 @@
 #include <cmath>
 #include <gtest/gtest.h>
 #include <quanergy/modules/encoder_angle_calibration.h>
+#include <random>
 
 namespace quanergy
 {


### PR DESCRIPTION
Added support for passing the polar-frame data to client applications. This for Jeff's mapper robot. karto requires a `sensor_msgs/LaserScan` message, and the quanergy client (and the ROS node) only output a point cloud. Adding support for a laser scan message was easier than modifying karto, so I went that route.